### PR TITLE
Add Scan and scanStream + modify set to use expiryMode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ This module provides a cache client that is compliant with the
 client implements the `await` style of the protocol.
 
 In addition to the API mandated by the protocol, the client exposes
-`keys`, `disconnect` and `quit` methods. These map to the
+`keys`, `scan`, `scanStream`, `disconnect` and `quit` methods. These map to the
 [ioredis](https://npm.im/ioredis) methods of the same names. The `disconnect`
 and `quit` methods are only useful if you create the client with connection
 configuration instead of an already connected Redis client.

--- a/index.js
+++ b/index.js
@@ -93,13 +93,7 @@ const proto = {
       stored: Date.now(),
       ttl
     }
-    // Supposedly there is some sort of "PX" option for Redis's `set()` method,
-    // but I have no idea how to use it. At least not with ioredis.
-    return this._redis.set(_key, JSON.stringify(payload))
-      .then(() => {
-        const ttlSec = Math.max(1, Math.floor(ttl / 1000))
-        return this._redis.expire(_key, ttlSec)
-      })
+    return this._redis.set(_key, JSON.stringify(payload), 'PX', ttl)
   }
 }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -71,6 +71,65 @@ test('keys() returns an array', (t) => {
     .catch(t.threw)
 })
 
+test('scan() returns an array when only cursor is provided', (t) => {
+  t.plan(4)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 1000)
+    .then(() => client.scan(0))
+    .then((result) => {
+      t.type(result, Array)
+      t.type(result[0], 'number')
+      t.type(result[1], Array)
+      t.is(result[1][0], 'foo')
+    })
+    .catch(t.threw)
+})
+
+test('scan() returns an array when match pattern is provided', (t) => {
+  t.plan(4)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 1000)
+    .then(() => client.scan(0, 'MATCH', 'fo*'))
+    .then((result) => {
+      t.type(result, Array)
+      t.type(result[0], 'number')
+      t.type(result[1], Array)
+      t.is(result[1][0], 'foo')
+    })
+    .catch(t.threw)
+})
+
+test('scan() returns an array when match pattern and count is provided', (t) => {
+  t.plan(5)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 1000)
+    .then(() => client.set('bar', 'bar', 1000).then(
+      () => client.scan(0, 'MATCH', '*', 'COUNT', 10))
+      .then((result) => {
+        t.type(result, Array)
+        t.type(result[0], 'number')
+        t.type(result[1], Array)
+        t.is(result[1][0], 'foo')
+        t.is(result[1][1], 'bar')
+      })
+    )
+    .catch(t.threw)
+})
+
+test('scanStream() returns an readable stream', (t) => {
+  t.plan(2)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 1000)
+    .then(() => client.set('bar', 'bar', 1000).then(
+      () => client.scanStream())
+      .then((result) => {
+        t.type(result, Object)
+        t.type(result.on, Function)
+      })
+    )
+    .catch(t.threw)
+})
+
 test('object keys work', (t) => {
   t.plan(3)
   const client = factory({ client: new MockIoredis() })

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -38,6 +38,32 @@ test('delete() removes item', (t) => {
     .catch(t.threw)
 })
 
+test('set() sets an item', (t) => {
+  t.plan(4)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 10000)
+    .then(() => client.get('foo'))
+    .then((result) => {
+      t.type(result, Object)
+      t.ok(result.item)
+      t.is(result.item, 'foo')
+      t.is(result.ttl > 0, true)
+    })
+    .catch(t.threw)
+})
+
+test('set() sets an item with propper expiry', (t) => {
+  t.plan(2)
+  const client = factory({ client: new MockIoredis() })
+  client.set('foo', 'foo', 0)
+    .then(() => client.get('foo'))
+    .then((result) => {
+      t.type(result, Object)
+      t.is(result.ttl <= 0, true)
+    })
+    .catch(t.threw)
+})
+
 test('get() returns `null`', (t) => {
   t.plan(1)
   const client = factory({ client: new MockIoredis() })


### PR DESCRIPTION
closes #4 

This PR

1. Adds scan and scanStream support.
2. modifies `set` to use ioredis `expiryMode` to set ttl in ms, to avoid unnecessary n/w call of setting ttl after setting key.
3. updates relevant tests
4. updates readme
